### PR TITLE
treewide: Fix error cause a function declaration is deprecated

### DIFF
--- a/drivers/staging/qca-wifi-host-cmn/hif/src/ce/ce_service_legacy.c
+++ b/drivers/staging/qca-wifi-host-cmn/hif/src/ce/ce_service_legacy.c
@@ -1317,7 +1317,7 @@ struct ce_ops ce_service_legacy = {
 #endif
 };
 
-struct ce_ops *ce_services_legacy()
+struct ce_ops *ce_services_legacy(void)
 {
 	return &ce_service_legacy;
 }

--- a/drivers/staging/qca-wifi-host-cmn/target_if/core/src/target_if_main.c
+++ b/drivers/staging/qca-wifi-host-cmn/target_if/core/src/target_if_main.c
@@ -88,7 +88,7 @@
 
 static struct target_if_ctx *g_target_if_ctx;
 
-struct target_if_ctx *target_if_get_ctx()
+struct target_if_ctx *target_if_get_ctx(void)
 {
 	return g_target_if_ctx;
 }

--- a/techpack/data/drivers/rmnet/perf/rmnet_perf_opt.c
+++ b/techpack/data/drivers/rmnet/perf/rmnet_perf_opt.c
@@ -712,7 +712,7 @@ void rmnet_perf_opt_insert_pkt_in_flow(
 		flow_node->next_seq += payload_len;
 }
 void
-rmnet_perf_free_hash_table()
+rmnet_perf_free_hash_table(void)
 {
 	int i;
 	struct rmnet_perf_opt_flow_node *flow_node;


### PR DESCRIPTION
Fixes warns on clang 15.0.0:

../techpack/data/drivers/rmnet/perf/rmnet_perf_opt.c:715:27: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
rmnet_perf_free_hash_table()
                          ^
                           void
  CC      net/bluetooth/hci_conn.o
  CC      drivers/base/attribute_container.o
1 error generated.

../drivers/staging/qcacld-3.0/../qca-wifi-host-cmn/target_if/core/src/target_if_main.c:91:40: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
struct target_if_ctx *target_if_get_ctx()
                                       ^
                                        void
1 error generated.
  CC      drivers/staging/qcacld-3.0/../qca-wifi-host-cmn/umac/dfs/core/src/misc/dfs_nol.o
make[4]: *** [../scripts/Makefile.build:364: drivers/staging/qcacld-3.0/../qca-wifi-host-cmn/target_if/core/src/target_if_main.o] Error 1
make[4]: *** Waiting for unfinished jobs....
../drivers/staging/qcacld-3.0/../qca-wifi-host-cmn/hif/src/ce/ce_service_legacy.c:1320:34: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
struct ce_ops *ce_services_legacy()
                                 ^
                                  void
1 error generated.

Signed-off-by: Fiqri Ardyansyah <fiqri15072019@gmail.com>
Signed-off-by: Pranav Temkar <pranavtemkar@gmail.com>