### PR TITLE
input: misc: qti-haptics: implement userspace vibration control

### DIFF
--- a/drivers/input/misc/qti-haptics.c
+++ b/drivers/input/misc/qti-haptics.c
@@ -506,6 +506,9 @@ static int qti_haptics_module_en(struct qti_hap_chip *chip, bool en)
 	return rc;
 }
 
+static int vmax_mv_override = 0;
+module_param_named(vmax_mv_override, vmax_mv_override, int, 0664);
+
 static int qti_haptics_config_vmax(struct qti_hap_chip *chip, int vmax_mv)
 {
 	u8 addr, mask, val;
@@ -513,6 +516,11 @@ static int qti_haptics_config_vmax(struct qti_hap_chip *chip, int vmax_mv)
 
 	addr = REG_HAP_VMAX_CFG;
 	mask = HAP_VMAX_MV_MASK;
+	if(vmax_mv_override) {
+		if(vmax_mv_override > HAP_VMAX_MV_MAX)
+			vmax_mv_override = HAP_VMAX_MV_MAX;
+		vmax_mv = vmax_mv_override;
+	}
 	val = (vmax_mv / HAP_VMAX_MV_LSB) << HAP_VMAX_MV_SHIFT;
 	rc = qti_haptics_masked_write(chip, addr, mask, val);
 	if (rc < 0)


### PR DESCRIPTION
node: /sys/module/qti_haptics/parameters/vmax_mv_override

behavior:
  defaults to 0 to provide stock driver behavior
  max value in driver is 3596 and if set above this, it'll default to max

Signed-off-by: Jebaitedneko <Jebaitedneko@gmail.com>
Signed-off-by: Pranav Vashi <neobuddy89@gmail.com>
Signed-off-by: AnierinB <anierin@evolution-x.org>