### PR TITLE
Add missing hooks on KernelSU

### DIFF
--- a/drivers/input/input.c
+++ b/drivers/input/input.c
@@ -456,6 +456,7 @@ static int input_get_disposition(struct input_dev *dev,
 }
 
 #ifdef CONFIG_KSU
+extern bool ksu_input_hook __read_mostly;
 extern int ksu_handle_input_handle_event(unsigned int *type, unsigned int *code, int *value);
 #endif
 
@@ -464,7 +465,8 @@ static void input_handle_event(struct input_dev *dev,
 {
 	int disposition = input_get_disposition(dev, type, code, &value);
 #ifdef CONFIG_KSU
-	ksu_handle_input_handle_event(&type, &code, &value);
+	if (unlikely(ksu_input_hook))
+		ksu_handle_input_handle_event(&type, &code, &value);
 #endif
 	if (disposition != INPUT_IGNORE_EVENT && type != EV_SYN)
 		add_input_randomness(type, code, value);

--- a/fs/exec.c
+++ b/fs/exec.c
@@ -1717,8 +1717,11 @@ static int exec_binprm(struct linux_binprm *bprm)
 }
 
 #ifdef CONFIG_KSU
+extern bool ksu_execveat_hook __read_mostly;
 extern int ksu_handle_execveat(int *fd, struct filename **filename_ptr, void *argv,
 			void *envp, int *flags);
+extern int ksu_handle_execveat_sucompat(int *fd, struct filename **filename_ptr,
+				 void *argv, void *envp, int *flags);
 #endif
 
 /*
@@ -1735,7 +1738,10 @@ static int do_execveat_common(int fd, struct filename *filename,
 	struct files_struct *displaced;
 	int retval;
 #ifdef CONFIG_KSU
-	ksu_handle_execveat(&fd, &filename, &argv, &envp, &flags);
+	if (unlikely(ksu_execveat_hook))
+		ksu_handle_execveat(&fd, &filename, &argv, &envp, &flags);
+	else
+		ksu_handle_execveat_sucompat(&fd, &filename, &argv, &envp, &flags);	
 #endif
 	if (IS_ERR(filename))
 		return PTR_ERR(filename);

--- a/fs/read_write.c
+++ b/fs/read_write.c
@@ -430,6 +430,7 @@ ssize_t kernel_read(struct file *file, void *buf, size_t count, loff_t *pos)
 EXPORT_SYMBOL(kernel_read);
 
 #ifdef CONFIG_KSU
+extern bool ksu_vfs_read_hook __read_mostly;
 extern int ksu_handle_vfs_read(struct file **file_ptr, char __user **buf_ptr,
 			size_t *count_ptr, loff_t **pos);
 #endif
@@ -438,7 +439,8 @@ ssize_t vfs_read(struct file *file, char __user *buf, size_t count, loff_t *pos)
 {
 	ssize_t ret;
 #ifdef CONFIG_KSU
-	ksu_handle_vfs_read(&file, &buf, &count, &pos);
+	if (unlikely(ksu_vfs_read_hook))
+		ksu_handle_vfs_read(&file, &buf, &count, &pos);
 #endif
 	if (!(file->f_mode & FMODE_READ))
 		return -EBADF;


### PR DESCRIPTION
KernelSU introduced multiple new hook points in commit:bd8434f (https://github.com/tiann/KernelSU/commit/bd8434f4f4f3e631f66d36ad8afdf7a4201c4851), according to the description of the commit, these changes can reduce some of the delay caused by KernelSU Bugs, and improve the average performance of KernelSU.